### PR TITLE
Fix: Correction de l'erreur de syntaxe dans CalculateurROI.jsx

### DIFF
--- a/src/components/CalculateurROI.jsx
+++ b/src/components/CalculateurROI.jsx
@@ -392,7 +392,7 @@ const CalculateurROI = () => {
     
     // Données pour le graphique des économies
     const dataEconomies = [
-      { name: 'Main d\\'œuvre', value: reductionMainOeuvre > 0 ? reductionMainOeuvre : 0 },
+      { name: "Main d'œuvre", value: reductionMainOeuvre > 0 ? reductionMainOeuvre : 0 },
       { name: 'Qualité', value: economiesQualite > 0 ? economiesQualite : 0 },
       { name: 'Sécurité', value: economiesSecurite + economiesTempsArret > 0 ? economiesSecurite + economiesTempsArret : 0 },
       { name: 'Production', value: differenceProduction * (parametresGeneraux.margeUnitaire) > 0 ? differenceProduction * (parametresGeneraux.margeUnitaire) : 0 },
@@ -1074,7 +1074,7 @@ const CalculateurROI = () => {
                 <CartesianGrid strokeDasharray="3 3" horizontal={true} vertical={false} />
                 <XAxis type="number" />
                 <YAxis dataKey="name" type="category" width={150} />
-                <Tooltip formatter={(value) => [`${value} ETP`, 'Main d\\'œuvre']} />
+                <Tooltip formatter={(value) => [`${value} ETP`, "Main d'œuvre"]} />
                 <Bar dataKey="value" nameKey="name" fill={(entry) => entry.fill} />
               </BarChart>
             </ResponsiveContainer>


### PR DESCRIPTION
Cette PR corrige l'erreur de syntaxe à la ligne 395 du fichier `CalculateurROI.jsx`, qui empêchait le build de l'application.

### Problème
Il y avait une erreur dans l'échappement de l'apostrophe dans la chaîne de caractères `'Main d\\'œuvre'`. Dans un template literal JavaScript (avec guillemets simples), nous n'avons pas besoin d'échapper les apostrophes.

### Solution
J'ai remplacé :
```javascript
{ name: 'Main d\\'œuvre', value: reductionMainOeuvre > 0 ? reductionMainOeuvre : 0 },
```

par :
```javascript
{ name: "Main d'œuvre", value: reductionMainOeuvre > 0 ? reductionMainOeuvre : 0 },
```

Cette correction permettra de résoudre l'erreur de compilation et de déployer correctement l'application.