### PR TITLE
Correction d'une erreur de compilation - variable economieQualite non définie

### DIFF
--- a/src/components/CalculateurROI.jsx
+++ b/src/components/CalculateurROI.jsx
@@ -230,6 +230,9 @@ const CalculateurROI = () => {
     // Calcul des économies liées à la réduction des rejets
     const economiesRejetsCalc = production * (tauxRejetsActuel - tauxRejetsAuto) / 100 * coutDechet;
     
+    // Calcul de l'économie liée à la qualité (sans facteur d'inflation)
+    const economieQualiteBase = production * (tauxProblemeQualite / 100) * (coutQualite / production);
+    
     // Calcul des économies et bénéfices annuels
     for (let annee = 1; annee <= dureeVie; annee++) {
       // Calcul des coûts ajustés avec l'inflation
@@ -251,7 +254,7 @@ const CalculateurROI = () => {
       const economieErreurs = coutErrorHumaine * facteurInflation;
       
       // Économies liées à la qualité
-      const economieQualite = production * (tauxProblemeQualite / 100) * (coutQualite / production) * facteurInflation;
+      const economieQualite = economieQualiteBase * facteurInflation;
       
       // Économies liées à la réduction des rejets
       const economieRejets = economiesRejetsCalc * facteurInflation;
@@ -346,7 +349,7 @@ const CalculateurROI = () => {
       economieAnnuelle: economieAnnuelleCalc,
       reductionMainOeuvre: reductionMainOeuvreCalc,
       economiesSecurite: economiesAccidents,
-      economiesQualite: economieQualite,
+      economiesQualite: economieQualiteBase, // Correction ici : utilisation de economieQualiteBase
       economiesTempsArret: economiesTempsArretCalc + economiesTempsArretNonPlanifie,
       economiesRejets: economiesRejetsCalc
     });


### PR DESCRIPTION
Cette PR corrige une erreur de compilation qui empêchait le déploiement sur Vercel.

## Problème
Une erreur ESLint a été détectée lors du déploiement dans le fichier `CalculateurROI.jsx` : la variable `economieQualite` était référencée dans la fonction `setResultats` mais n'était pas accessible dans sa portée, car elle était définie uniquement à l'intérieur de la boucle.

## Solution
J'ai ajouté une variable `economieQualiteBase` définie en dehors de la boucle pour calculer la valeur de base de l'économie de qualité (sans facteur d'inflation). Cette variable est ensuite utilisée dans `setResultats` à la place de la variable locale inaccessible.

Cette correction permettra au déploiement de réussir.