### PR TITLE
Dissocier les paramètres capacité et temps de cycle dans le calculateur général

### DIFF
--- a/src/components/CalculateurROI.jsx
+++ b/src/components/CalculateurROI.jsx
@@ -131,49 +131,7 @@ const CalculateurROI = () => {
     }
   }, [typeSystemeActuel]);
   
-  // Synchronisation du temps de cycle et de la capacité pour le système actuel
-  useEffect(() => {
-    // Ne mettre à jour que si la modification vient de la capacité (pour éviter boucle infinie)
-    if (parametresSystemeActuel.tempsCycle === 3600 / parametresSystemeActuel.capacite) return;
-    
-    setParametresSystemeActuel({
-      ...parametresSystemeActuel,
-      tempsCycle: Math.round(3600 / parametresSystemeActuel.capacite)
-    });
-  }, [parametresSystemeActuel.capacite]);
-  
-  // Synchronisation de la capacité et du temps de cycle pour le système actuel
-  useEffect(() => {
-    // Ne mettre à jour que si la modification vient du temps de cycle
-    if (parametresSystemeActuel.capacite === Math.round(3600 / parametresSystemeActuel.tempsCycle)) return;
-    
-    setParametresSystemeActuel({
-      ...parametresSystemeActuel,
-      capacite: Math.round(3600 / parametresSystemeActuel.tempsCycle)
-    });
-  }, [parametresSystemeActuel.tempsCycle]);
-  
-  // Synchronisation du temps de cycle et de la capacité pour le système automatisé
-  useEffect(() => {
-    // Ne mettre à jour que si la modification vient de la capacité
-    if (parametresSystemeAutomatise.tempsCycle === 3600 / parametresSystemeAutomatise.capacite) return;
-    
-    setParametresSystemeAutomatise({
-      ...parametresSystemeAutomatise,
-      tempsCycle: Math.round(3600 / parametresSystemeAutomatise.capacite)
-    });
-  }, [parametresSystemeAutomatise.capacite]);
-  
-  // Synchronisation de la capacité et du temps de cycle pour le système automatisé
-  useEffect(() => {
-    // Ne mettre à jour que si la modification vient du temps de cycle
-    if (parametresSystemeAutomatise.capacite === Math.round(3600 / parametresSystemeAutomatise.tempsCycle)) return;
-    
-    setParametresSystemeAutomatise({
-      ...parametresSystemeAutomatise,
-      capacite: Math.round(3600 / parametresSystemeAutomatise.tempsCycle)
-    });
-  }, [parametresSystemeAutomatise.tempsCycle]);
+  // Suppression des useEffect qui lient capacité et temps de cycle
   
   // Fonction de calcul des résultats
   const calculerROI = () => {
@@ -531,6 +489,7 @@ const CalculateurROI = () => {
                       })}
                       className="w-full p-2 border rounded"
                     />
+                    <p className="text-xs text-gray-500 mt-1">Volume de production horaire</p>
                   </div>
                   <div>
                     <label className="block text-sm font-medium mb-1">Temps de cycle (sec)</label>
@@ -543,6 +502,7 @@ const CalculateurROI = () => {
                       })}
                       className="w-full p-2 border rounded"
                     />
+                    <p className="text-xs text-gray-500 mt-1">Temps de traitement par unité</p>
                   </div>
                 </div>
               </div>
@@ -715,6 +675,7 @@ const CalculateurROI = () => {
                       })}
                       className="w-full p-2 border rounded"
                     />
+                    <p className="text-xs text-gray-500 mt-1">Volume de production horaire</p>
                   </div>
                   <div>
                     <label className="block text-sm font-medium mb-1">Temps de cycle (sec)</label>
@@ -727,6 +688,7 @@ const CalculateurROI = () => {
                       })}
                       className="w-full p-2 border rounded"
                     />
+                    <p className="text-xs text-gray-500 mt-1">Temps de traitement par unité</p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Description
Cette PR modifie le calculateur général de ROI pour dissocier les paramètres "capacité (unités/heure)" et "temps de cycle (secondes)". Actuellement, ces paramètres sont liés par une formule (Capacité = 3600 / Temps de cycle), ce qui n'est pas adapté à tous les types de systèmes d'automatisation.

## Modifications
- Suppression des effets useEffect qui synchronisaient automatiquement les valeurs de capacité et temps de cycle
- Ajout d'explications textuelles pour chaque paramètre
- Conservation des valeurs par défaut pour les différents types de systèmes

## Pourquoi cette modification?
Dans un calculateur général pour l'automatisation industrielle, les différents types de systèmes peuvent avoir des relations différentes entre capacité et temps de cycle:
- Certains systèmes peuvent traiter plusieurs unités en parallèle
- D'autres peuvent avoir des temps de préparation ou de transition
- La capacité peut dépendre d'autres facteurs que le seul temps de cycle
- Les unités de mesure peuvent varier (pièces, litres, kg, etc.)

En rendant ces paramètres indépendants, on permet aux utilisateurs de modéliser plus précisément leurs systèmes spécifiques, ce qui conduit à des calculs de ROI plus précis et réalistes.

## Tests
- Vérification manuelle que les champs capacité et temps de cycle peuvent désormais être modifiés indépendamment
- Validation que les calculs de ROI prennent bien en compte ces valeurs séparées