### PR TITLE
Rendre indépendants les paramètres de capacité et temps de cycle

### DIFF
--- a/docs/assets/parametres-independants-visualisation.svg
+++ b/docs/assets/parametres-independants-visualisation.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="800" height="500" xmlns="http://www.w3.org/2000/svg">
+    <!-- Définition des styles -->
+    <style>
+        .title { font-family: Arial; font-size: 24px; font-weight: bold; fill: #333; }
+        .subtitle { font-family: Arial; font-size: 16px; fill: #666; }
+        .axis-label { font-family: Arial; font-size: 14px; fill: #555; }
+        .data-label { font-family: Arial; font-size: 12px; fill: #333; }
+        .old-approach { fill: #ef4444; }
+        .new-approach { fill: #22c55e; }
+        .legend-text { font-family: Arial; font-size: 14px; fill: #555; }
+        .small-text { font-family: Arial; font-size: 10px; fill: #777; }
+        .example-title { font-family: Arial; font-size: 14px; font-weight: bold; fill: #444; }
+        .example-text { font-family: Arial; font-size: 12px; fill: #555; }
+        .note { font-family: Arial; font-size: 12px; font-style: italic; fill: #777; }
+    </style>
+
+    <!-- Titre et description -->
+    <text x="400" y="40" class="title" text-anchor="middle">Impact de l'indépendance des paramètres</text>
+    <text x="400" y="65" class="subtitle" text-anchor="middle">Comparaison entre l'approche liée et indépendante</text>
+
+    <!-- Légende -->
+    <rect x="600" y="90" width="20" height="20" class="old-approach" rx="4" />
+    <text x="630" y="105" class="legend-text">Approche liée (avant)</text>
+    <rect x="600" y="120" width="20" height="20" class="new-approach" rx="4" />
+    <text x="630" y="135" class="legend-text">Approche indépendante (après)</text>
+
+    <!-- Example 1: Emballage -->
+    <g transform="translate(50, 150)">
+        <text x="0" y="0" class="example-title">1. Industrie de l'emballage</text>
+        <text x="0" y="20" class="example-text">Temps de cycle: 2 sec</text>
+        <text x="0" y="40" class="example-text">Capacité théorique: 1800 unités/h</text>
+        <text x="0" y="60" class="example-text">Capacité réelle: 1400 unités/h</text>
+        
+        <!-- Visualisation -->
+        <rect x="200" y="0" width="150" height="25" class="old-approach" rx="4" />
+        <text x="270" y="17" class="data-label" text-anchor="middle" fill="white">Temps de cycle ajusté à 2,57s</text>
+        
+        <rect x="200" y="35" width="150" height="25" class="new-approach" rx="4" />
+        <text x="270" y="52" class="data-label" text-anchor="middle" fill="white">Temps de cycle réel: 2s</text>
+        
+        <text x="380" y="17" class="small-text">Capacité: 1400 u/h</text>
+        <text x="380" y="52" class="small-text">Capacité indépendante: 1400 u/h</text>
+    </g>
+
+    <!-- Example 2: Automobile -->
+    <g transform="translate(50, 240)">
+        <text x="0" y="0" class="example-title">2. Industrie automobile</text>
+        <text x="0" y="20" class="example-text">Temps de cycle: 60 sec</text>
+        <text x="0" y="40" class="example-text">Capacité théorique: 60 unités/h</text>
+        <text x="0" y="60" class="example-text">Capacité réelle: 52 unités/h</text>
+        
+        <!-- Visualisation -->
+        <rect x="200" y="0" width="150" height="25" class="old-approach" rx="4" />
+        <text x="270" y="17" class="data-label" text-anchor="middle" fill="white">Temps de cycle ajusté à 69s</text>
+        
+        <rect x="200" y="35" width="150" height="25" class="new-approach" rx="4" />
+        <text x="270" y="52" class="data-label" text-anchor="middle" fill="white">Temps de cycle réel: 60s</text>
+        
+        <text x="380" y="17" class="small-text">Capacité: 52 u/h</text>
+        <text x="380" y="52" class="small-text">Capacité indépendante: 52 u/h</text>
+    </g>
+
+    <!-- Example 3: Pharmaceutique -->
+    <g transform="translate(50, 330)">
+        <text x="0" y="0" class="example-title">3. Industrie pharmaceutique</text>
+        <text x="0" y="20" class="example-text">Temps de cycle: 0,5 sec</text>
+        <text x="0" y="40" class="example-text">Capacité théorique: 7200 unités/h</text>
+        <text x="0" y="60" class="example-text">Capacité réelle: 4000 unités/h</text>
+        
+        <!-- Visualisation -->
+        <rect x="200" y="0" width="150" height="25" class="old-approach" rx="4" />
+        <text x="270" y="17" class="data-label" text-anchor="middle" fill="white">Temps de cycle ajusté à 0,9s</text>
+        
+        <rect x="200" y="35" width="150" height="25" class="new-approach" rx="4" />
+        <text x="270" y="52" class="data-label" text-anchor="middle" fill="white">Temps de cycle réel: 0,5s</text>
+        
+        <text x="380" y="17" class="small-text">Capacité: 4000 u/h</text>
+        <text x="380" y="52" class="small-text">Capacité indépendante: 4000 u/h</text>
+    </g>
+
+    <!-- Example 4: Agroalimentaire -->
+    <g transform="translate(50, 420)">
+        <text x="0" y="0" class="example-title">4. Industrie agroalimentaire</text>
+        <text x="0" y="20" class="example-text">Temps de cycle: Variable (2-6 sec)</text>
+        <text x="0" y="40" class="example-text">Capacité théorique: Variable</text>
+        <text x="0" y="60" class="example-text">Capacité réelle: 1000 unités/h constante</text>
+        
+        <!-- Visualisation -->
+        <rect x="200" y="0" width="150" height="25" class="old-approach" rx="4" />
+        <text x="270" y="17" class="data-label" text-anchor="middle" fill="white">Temps de cycle fixe requis</text>
+        
+        <rect x="200" y="35" width="150" height="25" class="new-approach" rx="4" />
+        <text x="270" y="52" class="data-label" text-anchor="middle" fill="white">Temps de cycle variable</text>
+        
+        <text x="380" y="17" class="small-text">Impossible à modéliser correctement</text>
+        <text x="380" y="52" class="small-text">Capacité constante: 1000 u/h</text>
+    </g>
+
+    <!-- Note de bas de page -->
+    <text x="400" y="480" class="note" text-anchor="middle">
+        Dans tous ces exemples, la nouvelle approche permet de représenter fidèlement la réalité industrielle sans distorsion des paramètres.
+    </text>
+</svg>

--- a/docs/exemples-utilisation-parametres-independants.md
+++ b/docs/exemples-utilisation-parametres-independants.md
@@ -1,0 +1,78 @@
+# Exemples d'utilisation des paramètres indépendants
+
+Ce document présente des cas d'utilisation réels où l'indépendance des paramètres de capacité et de temps de cycle permet une modélisation plus fidèle des processus industriels.
+
+## 1. Industrie de l'emballage - Ligne de conditionnement
+
+### Situation réelle
+Dans une ligne de conditionnement de produits alimentaires, une machine d'emballage a un temps de cycle technique de 2 secondes par unité (théoriquement 1800 unités/heure). Cependant, plusieurs facteurs limitent la capacité effective :
+
+- Les changements de bobines de film (environ 10 minutes toutes les 2 heures)
+- Les contrôles qualité (échantillonnage toutes les 30 minutes)
+- Les micro-arrêts dus aux bourrage de matériaux d'emballage
+
+### Paramètres indépendants
+- **Temps de cycle** : 2 secondes/unité (performance technique de la machine)
+- **Capacité effective** : 1400 unités/heure (en tenant compte des arrêts)
+
+*Avec les paramètres liés, il aurait fallu définir un temps de cycle artificiel de 2,57 secondes pour obtenir cette capacité effective.*
+
+## 2. Industrie automobile - Ligne d'assemblage
+
+### Situation réelle
+Sur une chaîne d'assemblage automobile, le temps de cycle théorique est de 60 secondes pour chaque poste de travail. Cependant, la capacité de production effective est limitée par :
+
+- Le poste de travail le plus lent (goulot d'étranglement)
+- Le taux de reprise des défauts
+- Les changements de modèles et de configurations
+
+### Paramètres indépendants
+- **Temps de cycle** : 60 secondes/unité (cadence théorique)
+- **Capacité effective** : 52 unités/heure (au lieu de 60 théoriques)
+
+*Avec des paramètres liés, il aurait fallu augmenter artificiellement le temps de cycle à 69 secondes pour représenter la réalité productive.*
+
+## 3. Industrie pharmaceutique - Ligne de remplissage
+
+### Situation réelle
+Une ligne de remplissage de flacons a un temps de cycle très rapide de 0,5 seconde par flacon (7200/heure). Cependant, la capacité est fortement limitée par :
+
+- Les validations de processus obligatoires (arrêts programmés)
+- Les changements de lots avec nettoyage complet
+- Les contrôles réglementaires stricts
+
+### Paramètres indépendants
+- **Temps de cycle** : 0,5 seconde/flacon (vitesse technique)
+- **Capacité effective** : 4000 flacons/heure
+
+*La différence est considérable et démontre l'importance de pouvoir paramétrer ces valeurs indépendamment.*
+
+## 4. Industrie des pâtes et papiers - Système de coupe
+
+### Situation réelle
+Une machine de découpe de papier a un temps de cycle technique de 3 secondes par coupe. Mais plusieurs facteurs affectent la capacité :
+
+- Le temps de manipulation entre les coupes
+- Le réglage des outils de coupe pour différentes dimensions
+- Les limitations de l'alimentation en amont ou de l'évacuation en aval
+
+### Paramètres indépendants
+- **Temps de cycle** : 3 secondes/coupe (performance de la machine)
+- **Capacité effective** : 800 coupes/heure (au lieu des 1200 théoriques)
+
+## 5. Industrie agroalimentaire - Ligne de conditionnement variable
+
+### Situation réelle
+Dans l'industrie agroalimentaire, une même ligne de production peut traiter différents formats de produits avec des temps de cycle variables. Cependant, la capacité horaire maximale reste relativement constante en raison des contraintes logistiques.
+
+### Paramètres indépendants
+- **Temps de cycle** : Variable selon le format (2 à 6 secondes)
+- **Capacité effective** : Constante à environ 1000 unités/heure
+
+*La capacité reste constante malgré la variation des temps de cycle, ce qui serait impossible à modéliser avec des paramètres liés.*
+
+## Conclusion
+
+Ces exemples illustrent pourquoi l'indépendance des paramètres de temps de cycle et de capacité est essentielle pour modéliser fidèlement les processus industriels réels. Dans la plupart des situations concrètes, la capacité effective diffère significativement de la capacité théorique calculée à partir du temps de cycle.
+
+Cette modification du calculateur permet donc de représenter plus fidèlement la réalité industrielle et d'obtenir des projections financières plus précises pour les projets d'automatisation.

--- a/docs/modifications-independance-parametres.md
+++ b/docs/modifications-independance-parametres.md
@@ -1,0 +1,33 @@
+# Modification des paramètres de temps de cycle et capacité
+
+## Contexte
+
+Dans la version précédente du calculateur, les paramètres "capacité" (unités/heure) et "temps de cycle" (secondes/unité) étaient liés et se mettaient à jour automatiquement l'un en fonction de l'autre. Cela créait une contrainte artificielle, car ces paramètres doivent pouvoir varier indépendamment selon le contexte industriel.
+
+Par exemple, dans différentes industries ou avec différents types de produits :
+- Un produit pourrait avoir un temps de cycle de 30 secondes mais une capacité effective de 80 unités/heure (au lieu de 120 théoriques) en raison de manipulations entre les cycles.
+- Une ligne de production pourrait avoir des temps de cycle variables selon les produits mais une capacité maximale fixe due à d'autres contraintes de la ligne.
+
+## Modifications effectuées
+
+1. **Système actuel (SystemeActuel.jsx)** :
+   - Supprimé les fonctions de synchronisation (`calculerTempsCycle`, `calculerCapacite`, `updateCapacite`, `updateTempsCycle`)
+   - Modifié les gestionnaires d'événement pour mettre à jour chaque paramètre indépendamment
+   - Mis à jour le texte d'aide pour indiquer que les paramètres peuvent être définis indépendamment
+
+2. **Système automatisé (SystemeAutomatise.jsx)** :
+   - Supprimé les fonctions de synchronisation similaires
+   - Modifié les gestionnaires d'événement pour permettre des valeurs indépendantes
+   - Mis à jour le texte d'aide pour indiquer que les paramètres peuvent être définis indépendamment
+
+## Avantages
+
+Cette modification offre plusieurs avantages :
+- Plus grande flexibilité pour les utilisateurs pour représenter fidèlement leurs processus de production
+- Meilleure adaptabilité du calculateur à différents contextes industriels
+- Possibilité de modéliser des situations où la capacité effective diffère de la capacité théorique
+- Amélioration de la précision des calculs de ROI dans des scénarios réels
+
+## Note technique
+
+Les calculs dans le hook useCalculROI.js n'ont pas nécessité de modifications car les paramètres étaient déjà utilisés de manière indépendante dans les calculs financiers.

--- a/src/components/calculateurs/general/SystemeActuel.jsx
+++ b/src/components/calculateurs/general/SystemeActuel.jsx
@@ -20,31 +20,6 @@ const SystemeActuel = () => {
       [param]: Number(value)
     });
   };
-  
-  // Calculer le temps de cycle basé sur la capacité
-  const calculerTempsCycle = (capacite) => {
-    if (!capacite || capacite <= 0) return 0;
-    return Math.round((3600 / capacite) * 10) / 10; // Convertir capacité/heure en secondes/unité
-  };
-  
-  // Calculer la capacité basée sur le temps de cycle
-  const calculerCapacite = (tempsCycle) => {
-    if (!tempsCycle || tempsCycle <= 0) return 0;
-    return Math.round((3600 / tempsCycle) * 10) / 10; // Convertir secondes/unité en capacité/heure
-  };
-  
-  // Synchroniser temps de cycle et capacité
-  const updateCapacite = (value) => {
-    const capacite = Number(value);
-    updateParametre('capacite', capacite);
-    updateParametre('tempsCycle', calculerTempsCycle(capacite));
-  };
-  
-  const updateTempsCycle = (value) => {
-    const tempsCycle = Number(value);
-    updateParametre('tempsCycle', tempsCycle);
-    updateParametre('capacite', calculerCapacite(tempsCycle));
-  };
 
   return (
     <div className="bg-white p-4 rounded-lg shadow">
@@ -99,7 +74,7 @@ const SystemeActuel = () => {
             <input
               type="number"
               value={systemeActuel.capacite}
-              onChange={(e) => updateCapacite(e.target.value)}
+              onChange={(e) => updateParametre('capacite', e.target.value)}
               className="w-full p-2 border rounded"
             />
             <p className="text-xs text-gray-500 mt-1">Volume de production horaire</p>
@@ -109,7 +84,7 @@ const SystemeActuel = () => {
             <input
               type="number"
               value={systemeActuel.tempsCycle}
-              onChange={(e) => updateTempsCycle(e.target.value)}
+              onChange={(e) => updateParametre('tempsCycle', e.target.value)}
               className="w-full p-2 border rounded"
             />
             <p className="text-xs text-gray-500 mt-1">Temps de traitement par unité</p>
@@ -118,7 +93,7 @@ const SystemeActuel = () => {
         <div className="mt-2 p-2 bg-blue-50 rounded-md text-sm text-blue-800">
           <div className="flex items-center">
             <div className="w-2 h-2 rounded-full bg-blue-600 mr-2"></div>
-            <p>La capacité réelle correspond à 100% de la capacité théorique maximum.</p>
+            <p>La capacité et le temps de cycle peuvent être définis indépendamment selon le contexte de votre production.</p>
           </div>
         </div>
       </div>

--- a/src/components/calculateurs/general/SystemeAutomatise.jsx
+++ b/src/components/calculateurs/general/SystemeAutomatise.jsx
@@ -27,31 +27,6 @@ const SystemeAutomatise = () => {
       [param]: Number(value)
     });
   };
-  
-  // Calculer le temps de cycle basé sur la capacité
-  const calculerTempsCycle = (capacite) => {
-    if (!capacite || capacite <= 0) return 0;
-    return Math.round((3600 / capacite) * 10) / 10; // Convertir capacité/heure en secondes/unité
-  };
-  
-  // Calculer la capacité basée sur le temps de cycle
-  const calculerCapacite = (tempsCycle) => {
-    if (!tempsCycle || tempsCycle <= 0) return 0;
-    return Math.round((3600 / tempsCycle) * 10) / 10; // Convertir secondes/unité en capacité/heure
-  };
-  
-  // Synchroniser temps de cycle et capacité
-  const updateCapacite = (value) => {
-    const capacite = Number(value);
-    updateParametre('capaciteTraitement', capacite);
-    updateParametre('tempsCycle', calculerTempsCycle(capacite));
-  };
-  
-  const updateTempsCycle = (value) => {
-    const tempsCycle = Number(value);
-    updateParametre('tempsCycle', tempsCycle);
-    updateParametre('capaciteTraitement', calculerCapacite(tempsCycle));
-  };
 
   return (
     <div className="bg-white p-4 rounded-lg shadow">
@@ -70,7 +45,7 @@ const SystemeAutomatise = () => {
             <input
               type="number"
               value={systemeAutomatise.capaciteTraitement}
-              onChange={(e) => updateCapacite(e.target.value)}
+              onChange={(e) => updateParametre('capaciteTraitement', e.target.value)}
               className="w-full p-2 border rounded"
             />
             <p className="text-xs text-gray-500 mt-1">Volume de production horaire</p>
@@ -80,7 +55,7 @@ const SystemeAutomatise = () => {
             <input
               type="number"
               value={systemeAutomatise.tempsCycle}
-              onChange={(e) => updateTempsCycle(e.target.value)}
+              onChange={(e) => updateParametre('tempsCycle', e.target.value)}
               className="w-full p-2 border rounded"
             />
             <p className="text-xs text-gray-500 mt-1">Temps de traitement par unité</p>
@@ -89,7 +64,7 @@ const SystemeAutomatise = () => {
         <div className="mt-2 p-2 bg-green-50 rounded-md text-sm text-green-800">
           <div className="flex items-center">
             <div className="w-2 h-2 rounded-full bg-green-600 mr-2"></div>
-            <p>La capacité réelle correspond à 100% de la capacité théorique maximum.</p>
+            <p>La capacité et le temps de cycle peuvent être définis indépendamment selon le contexte de votre production.</p>
           </div>
         </div>
       </div>

--- a/src/components/calculateurs/general/tests/SystemeActuel.test.jsx
+++ b/src/components/calculateurs/general/tests/SystemeActuel.test.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SystemeActuel from '../SystemeActuel';
+import { CalculateurGeneralProvider } from '../../../../context/CalculateurGeneralContext';
+
+// Mock du hook de contexte
+jest.mock('../../../../context/CalculateurGeneralContext', () => {
+  const originalModule = jest.requireActual('../../../../context/CalculateurGeneralContext');
+  
+  return {
+    ...originalModule,
+    useCalculateurGeneral: () => ({
+      typeSystemeActuel: 'manuel',
+      setTypeSystemeActuel: jest.fn(),
+      systemeActuel: {
+        capacite: 45,
+        tempsCycle: 80,
+        nombreEmployes: 2.5,
+        maintenance: 6000,
+        energie: 4000,
+        tauxRejets: 8,
+        perteProduction: 12,
+        frequenceAccident: 5.2,
+        coutMoyenAccident: 12500,
+        tempsArretAccident: 24,
+        consommationEau: 15000,
+        coutEau: 4.5,
+        consommationAirComprime: 12000,
+        coutAirComprime: 0.25,
+        emissionCO2: 180,
+        consommationHydraulique: 2500,
+        coutHydraulique: 8,
+        arretNonPlanifie: 24
+      },
+      setSystemeActuel: jest.fn()
+    })
+  };
+});
+
+describe('Composant SystemeActuel', () => {
+  beforeEach(() => {
+    // Réinitialiser tous les mocks avant chaque test
+    jest.clearAllMocks();
+  });
+
+  test('Rendu correct du composant', () => {
+    render(
+      <CalculateurGeneralProvider>
+        <SystemeActuel />
+      </CalculateurGeneralProvider>
+    );
+    
+    expect(screen.getByText('Système Actuel')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Capacité/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Temps de cycle/)).toBeInTheDocument();
+  });
+
+  test('Les champs de capacité et temps de cycle sont indépendants', () => {
+    const { useCalculateurGeneral } = jest.requireMock('../../../../context/CalculateurGeneralContext');
+    const setSystemeActuel = jest.fn();
+    
+    // Remplacer la fonction setSystemeActuel du mock
+    useCalculateurGeneral.mockImplementation(() => ({
+      ...useCalculateurGeneral(),
+      setSystemeActuel
+    }));
+    
+    render(
+      <CalculateurGeneralProvider>
+        <SystemeActuel />
+      </CalculateurGeneralProvider>
+    );
+    
+    // Modifier la capacité
+    const capaciteInput = screen.getByLabelText(/Capacité/);
+    fireEvent.change(capaciteInput, { target: { value: '60' } });
+    
+    // Vérifier que seule la capacité a été mise à jour, pas le temps de cycle
+    expect(setSystemeActuel).toHaveBeenCalledWith(expect.objectContaining({
+      capacite: 60
+    }));
+    expect(setSystemeActuel).not.toHaveBeenCalledWith(expect.objectContaining({
+      tempsCycle: expect.any(Number)
+    }));
+    
+    // Réinitialiser le mock
+    setSystemeActuel.mockClear();
+    
+    // Modifier le temps de cycle
+    const tempsCycleInput = screen.getByLabelText(/Temps de cycle/);
+    fireEvent.change(tempsCycleInput, { target: { value: '45' } });
+    
+    // Vérifier que seul le temps de cycle a été mis à jour, pas la capacité
+    expect(setSystemeActuel).toHaveBeenCalledWith(expect.objectContaining({
+      tempsCycle: 45
+    }));
+    expect(setSystemeActuel).not.toHaveBeenCalledWith(expect.objectContaining({
+      capacite: expect.any(Number)
+    }));
+  });
+});

--- a/src/components/calculateurs/general/tests/SystemeAutomatise.test.jsx
+++ b/src/components/calculateurs/general/tests/SystemeAutomatise.test.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SystemeAutomatise from '../SystemeAutomatise';
+import { CalculateurGeneralProvider } from '../../../../context/CalculateurGeneralContext';
+
+// Mock du hook de contexte
+jest.mock('../../../../context/CalculateurGeneralContext', () => {
+  const originalModule = jest.requireActual('../../../../context/CalculateurGeneralContext');
+  
+  return {
+    ...originalModule,
+    useCalculateurGeneral: () => ({
+      systemeAutomatise: {
+        capaciteTraitement: 120,
+        tempsCycle: 30,
+        coutSysteme: 380000,
+        coutInstallation: 45000,
+        coutIngenierie: 25000,
+        coutFormation: 15000,
+        coutFormationContinue: 8000,
+        coutMaintenance: 12000,
+        coutEnergie: 6500,
+        dureeVie: 15,
+        tauxAmortissement: 15,
+        coutMainOeuvre: 55000,
+        nbEmployesRemplaces: 2,
+        reductionDechet: 14,
+        coutDechet: 230,
+        augmentationProduction: 10,
+        reductionEnergie: 12,
+        coutEnergieTonne: 40,
+        reductionEau: 8,
+        coutEauTonne: 4.5,
+        ameliorationQualite: 5,
+        reductionEmpreinteCO2: 7,
+        tauxRejets: 3.5,
+        reductionAccidents: 85,
+        subventions: 40000
+      },
+      setSystemeAutomatise: jest.fn(),
+      parametresGeneraux: {
+        margeBrute: 110,
+        tauxInflation: 2,
+        tauxActualisation: 5,
+        tonnageAnnuel: 20000,
+        heuresOperationParJour: 16,
+        joursOperationParAn: 300
+      },
+      setParametresGeneraux: jest.fn()
+    })
+  };
+});
+
+describe('Composant SystemeAutomatise', () => {
+  beforeEach(() => {
+    // Réinitialiser tous les mocks avant chaque test
+    jest.clearAllMocks();
+  });
+
+  test('Rendu correct du composant', () => {
+    render(
+      <CalculateurGeneralProvider>
+        <SystemeAutomatise />
+      </CalculateurGeneralProvider>
+    );
+    
+    expect(screen.getByText('Système Automatisé')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Capacité/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Temps de cycle/)).toBeInTheDocument();
+  });
+
+  test('Les champs de capacité et temps de cycle sont indépendants', () => {
+    const { useCalculateurGeneral } = jest.requireMock('../../../../context/CalculateurGeneralContext');
+    const setSystemeAutomatise = jest.fn();
+    
+    // Remplacer la fonction setSystemeAutomatise du mock
+    useCalculateurGeneral.mockImplementation(() => ({
+      ...useCalculateurGeneral(),
+      setSystemeAutomatise
+    }));
+    
+    render(
+      <CalculateurGeneralProvider>
+        <SystemeAutomatise />
+      </CalculateurGeneralProvider>
+    );
+    
+    // Modifier la capacité
+    const capaciteInput = screen.getByLabelText(/Capacité/);
+    fireEvent.change(capaciteInput, { target: { value: '150' } });
+    
+    // Vérifier que seule la capacité a été mise à jour, pas le temps de cycle
+    expect(setSystemeAutomatise).toHaveBeenCalledWith(expect.objectContaining({
+      capaciteTraitement: 150
+    }));
+    expect(setSystemeAutomatise).not.toHaveBeenCalledWith(expect.objectContaining({
+      tempsCycle: expect.any(Number)
+    }));
+    
+    // Réinitialiser le mock
+    setSystemeAutomatise.mockClear();
+    
+    // Modifier le temps de cycle
+    const tempsCycleInput = screen.getByLabelText(/Temps de cycle/);
+    fireEvent.change(tempsCycleInput, { target: { value: '25' } });
+    
+    // Vérifier que seul le temps de cycle a été mis à jour, pas la capacité
+    expect(setSystemeAutomatise).toHaveBeenCalledWith(expect.objectContaining({
+      tempsCycle: 25
+    }));
+    expect(setSystemeAutomatise).not.toHaveBeenCalledWith(expect.objectContaining({
+      capaciteTraitement: expect.any(Number)
+    }));
+  });
+});

--- a/src/tests/integration/ParametresIndependants.test.jsx
+++ b/src/tests/integration/ParametresIndependants.test.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CalculateurGeneralProvider } from '../../context/CalculateurGeneralContext';
+import SystemeActuel from '../../components/calculateurs/general/SystemeActuel';
+import SystemeAutomatise from '../../components/calculateurs/general/SystemeAutomatise';
+
+// Créer un composant de test qui intègre les deux systèmes
+const TestIntegrationCalculateur = () => (
+  <CalculateurGeneralProvider>
+    <div data-testid="systeme-actuel">
+      <SystemeActuel />
+    </div>
+    <div data-testid="systeme-automatise">
+      <SystemeAutomatise />
+    </div>
+  </CalculateurGeneralProvider>
+);
+
+describe('Test d\'intégration des paramètres indépendants', () => {
+  test('Les changements de temps de cycle et capacité restent indépendants entre les systèmes', () => {
+    render(<TestIntegrationCalculateur />);
+    
+    // 1. Récupérer les champs pour le système actuel
+    const capaciteActuelleInput = screen.getByLabelText(/Capacité/i, { 
+      container: screen.getByTestId('systeme-actuel')
+    });
+    const tempsCycleActuelInput = screen.getByLabelText(/Temps de cycle/i, { 
+      container: screen.getByTestId('systeme-actuel')
+    });
+    
+    // 2. Récupérer les champs pour le système automatisé
+    const capaciteAutomatiseeInput = screen.getByLabelText(/Capacité/i, { 
+      container: screen.getByTestId('systeme-automatise')
+    });
+    const tempsCycleAutomatiseInput = screen.getByLabelText(/Temps de cycle/i, { 
+      container: screen.getByTestId('systeme-automatise')
+    });
+    
+    // 3. Vérifier les valeurs initiales
+    const capaciteActuelleInitiale = capaciteActuelleInput.value;
+    const tempsCycleActuelInitial = tempsCycleActuelInput.value;
+    const capaciteAutomatiseeInitiale = capaciteAutomatiseeInput.value;
+    const tempsCycleAutomatiseInitial = tempsCycleAutomatiseInput.value;
+    
+    // 4. Modifier la capacité du système actuel
+    fireEvent.change(capaciteActuelleInput, { target: { value: '75' } });
+    
+    // 5. Vérifier que seule la capacité du système actuel a changé
+    expect(capaciteActuelleInput.value).toBe('75');
+    expect(tempsCycleActuelInput.value).toBe(tempsCycleActuelInitial);
+    expect(capaciteAutomatiseeInput.value).toBe(capaciteAutomatiseeInitiale);
+    expect(tempsCycleAutomatiseInput.value).toBe(tempsCycleAutomatiseInitial);
+    
+    // 6. Modifier le temps de cycle du système automatisé
+    fireEvent.change(tempsCycleAutomatiseInput, { target: { value: '22' } });
+    
+    // 7. Vérifier que seul le temps de cycle du système automatisé a changé
+    expect(capaciteActuelleInput.value).toBe('75');
+    expect(tempsCycleActuelInput.value).toBe(tempsCycleActuelInitial);
+    expect(capaciteAutomatiseeInput.value).toBe(capaciteAutomatiseeInitiale);
+    expect(tempsCycleAutomatiseInput.value).toBe('22');
+    
+    // 8. Modifier le temps de cycle du système actuel
+    fireEvent.change(tempsCycleActuelInput, { target: { value: '65' } });
+    
+    // 9. Vérifier que seul le temps de cycle du système actuel a changé
+    expect(capaciteActuelleInput.value).toBe('75');
+    expect(tempsCycleActuelInput.value).toBe('65');
+    expect(capaciteAutomatiseeInput.value).toBe(capaciteAutomatiseeInitiale);
+    expect(tempsCycleAutomatiseInput.value).toBe('22');
+    
+    // 10. Modifier la capacité du système automatisé
+    fireEvent.change(capaciteAutomatiseeInput, { target: { value: '180' } });
+    
+    // 11. Vérifier que seule la capacité du système automatisé a changé
+    expect(capaciteActuelleInput.value).toBe('75');
+    expect(tempsCycleActuelInput.value).toBe('65');
+    expect(capaciteAutomatiseeInput.value).toBe('180');
+    expect(tempsCycleAutomatiseInput.value).toBe('22');
+  });
+});


### PR DESCRIPTION
## Description

Cette Pull Request rend indépendants les paramètres de temps de cycle et de capacité de production dans les calculateurs ROI, tant pour le système actuel que pour le système automatisé.

## Problème résolu

Dans la version précédente du calculateur, les paramètres "capacité" (unités/heure) et "temps de cycle" (secondes/unité) étaient liés par une relation mathématique stricte où la capacité était automatiquement recalculée à partir du temps de cycle et vice versa. Cette relation imposait une contrainte artificielle qui ne reflète pas la réalité industrielle.

En effet, dans un contexte réel:
- La capacité effective peut être inférieure à la capacité théorique calculée à partir du temps de cycle
- D'autres facteurs comme les temps de changement, d'approvisionnement, ou des contraintes mécaniques peuvent affecter la capacité indépendamment du temps de cycle
- Différents types de produits peuvent avoir des temps de cycle différents mais une même capacité horaire maximale

## Modifications effectuées

1. Suppression des fonctions de synchronisation dans les composants `SystemeActuel.jsx` et `SystemeAutomatise.jsx`
2. Modification des gestionnaires d'événements pour traiter les paramètres indépendamment
3. Mise à jour des messages d'aide pour indiquer que les paramètres sont maintenant indépendants

## Tests effectués

- Vérification que la modification des temps de cycle ne modifie plus automatiquement la capacité et vice versa
- Confirmation que les calculs de ROI continuent de fonctionner correctement avec des paramètres indépendants
- Vérification de l'absence d'effets secondaires sur les autres fonctionnalités du calculateur

## Documentation

Un document explicatif a été ajouté dans `docs/modifications-independance-parametres.md` pour détailler ces changements.