### PR TITLE
Suppression de l'import react-router-dom inutilisé qui causait une erreur de build

### DIFF
--- a/src/components/communs/DocumentationLink.jsx
+++ b/src/components/communs/DocumentationLink.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 
 /**
  * Composant réutilisable pour lier vers la documentation


### PR DESCRIPTION
## Description
Cette pull request corrige l'erreur de build qui s'est produite après la fusion de la PR #56. Le déploiement sur Vercel a échoué avec l'erreur suivante :

```
Module not found: Error: Can't resolve 'react-router-dom' in '/vercel/path0/src/components/communs'
```

## Problème
Dans le composant `DocumentationLink.jsx`, nous avions importé `useNavigate` de `react-router-dom`, mais cette dépendance n'est pas installée dans le projet ou n'est pas correctement configurée.

## Solution
J'ai supprimé l'import inutilisé de `react-router-dom` puisque nous n'utilisons pas cette fonctionnalité dans notre implémentation actuelle. Les liens sont maintenant des liens absolus vers GitHub, ce qui ne nécessite pas de navigation programmatique.

## Changements effectués
- Suppression de la ligne d'import `import { useNavigate } from 'react-router-dom';` dans `DocumentationLink.jsx`
- Aucune autre modification n'était nécessaire car le reste du composant ne dépendait pas de cette importation

## Tests
Cette solution devrait permettre au build de réussir et au déploiement de fonctionner correctement sur Vercel.