### PR TITLE
Correction des erreurs de build dans le Footer

### DIFF
--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -37,13 +37,13 @@ const Footer = () => {
                   Revoir les conditions d'utilisation
                 </button>
                 <button 
-                  onClick={() => setTermsModal(true)}
+                  onClick={() => setShowTermsModal(true)}
                   className="text-blue-600 hover:text-blue-800 font-medium focus:outline-none underline"
                 >
                   Termes et conditions
                 </button>
                 <button 
-                  onClick={() => setPrivacyModal(true)}
+                  onClick={() => setShowPrivacyModal(true)}
                   className="text-blue-600 hover:text-blue-800 font-medium focus:outline-none underline"
                 >
                   Politique de confidentialité


### PR DESCRIPTION
## Correction des erreurs d'undefined dans le footer

Cette PR corrige les erreurs qui empêchent le build de l'application en production :

1. **Erreur corrigée** : Variables non définies dans le footer:
   - `'setTermsModal' is not defined no-undef`
   - `'setPrivacyModal' is not defined no-undef`

2. **Solution** : 
   - Utilisation des noms corrects des fonctions setter d'état : `setShowTermsModal` et `setShowPrivacyModal` au lieu de `setTermsModal` et `setPrivacyModal`
   - Ces noms correspondent aux états définis au début du composant Footer

Cette correction permettra au déploiement de se terminer avec succès.