### PR TITLE
Mise à jour des boutons de documentation pour utiliser FormulasModal

### DIFF
--- a/src/components/calculateurs/general/ResultatsROI.jsx
+++ b/src/components/calculateurs/general/ResultatsROI.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useCalculateurGeneral } from '../../../context/CalculateurGeneralContext';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, BarChart, Bar } from 'recharts';
 import InfoBulle from '../../communs/InfoBulle';
+import FormulasModal from '../../FormulasModal';
 
 /**
  * Composant pour afficher les résultats financiers du ROI
@@ -16,6 +17,9 @@ const ResultatsROI = () => {
   
   // État local pour l'affichage du détail des coûts cachés
   const [afficherDetailCoutsCache, setAfficherDetailCoutsCache] = useState(false);
+  
+  // État pour le modal de formules
+  const [isFormulasModalOpen, setIsFormulasModalOpen] = useState(false);
   
   // Extraction des valeurs pertinentes
   const {
@@ -63,16 +67,15 @@ const ResultatsROI = () => {
           </svg>
           Résultats financiers
         </h2>
-        <a 
-          href="/docs/formules-calculateur-general.md" 
-          target="_blank"
+        <button 
+          onClick={() => setIsFormulasModalOpen(true)}
           className="text-sm text-blue-600 hover:text-blue-800 hover:underline flex items-center"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           Documentation des formules
-        </a>
+        </button>
       </div>
       
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
@@ -368,6 +371,13 @@ const ResultatsROI = () => {
           </p>
         </div>
       </div>
+
+      {/* Modal des formules */}
+      <FormulasModal 
+        isOpen={isFormulasModalOpen} 
+        onClose={() => setIsFormulasModalOpen(false)} 
+        document="formules-calculateur-general.md"
+      />
     </div>
   );
 };

--- a/src/components/calculateurs/general/SystemeActuel.jsx
+++ b/src/components/calculateurs/general/SystemeActuel.jsx
@@ -4,6 +4,7 @@ import { TYPES_SYSTEME } from '../../../utils/constants';
 import { validateParams } from '../../../utils/validationService';
 import InfoBulle from '../../communs/InfoBulle';
 import { descriptionSystemeActuel } from '../../../utils/parametresDescriptions';
+import FormulasModal from '../../FormulasModal';
 
 /**
  * Composant pour les paramètres du système actuel
@@ -18,6 +19,9 @@ const SystemeActuel = () => {
   
   // État local pour les erreurs de validation
   const [erreurs, setErreurs] = useState({});
+  
+  // État pour le modal de formules
+  const [isFormulasModalOpen, setIsFormulasModalOpen] = useState(false);
   
   // Fonction pour mettre à jour un paramètre spécifique
   const updateParametre = (param, value) => {
@@ -482,17 +486,23 @@ const SystemeActuel = () => {
 
       {/* Lien vers la documentation des formules */}
       <div className="mt-6 text-center">
-        <a 
-          href="/docs/formules-calculateur-general.md" 
-          target="_blank"
-          className="text-sm text-blue-600 hover:text-blue-800 hover:underline flex items-center justify-center"
+        <button 
+          onClick={() => setIsFormulasModalOpen(true)}
+          className="text-sm text-blue-600 hover:text-blue-800 hover:underline flex items-center justify-center mx-auto"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           Consulter la documentation détaillée des formules utilisées
-        </a>
+        </button>
       </div>
+
+      {/* Modal des formules */}
+      <FormulasModal 
+        isOpen={isFormulasModalOpen} 
+        onClose={() => setIsFormulasModalOpen(false)} 
+        document="formules-calculateur-general.md"
+      />
 
       {/* Affichage d'erreurs globales si nécessaire */}
       {Object.keys(erreurs).length > 0 && (

--- a/src/components/calculateurs/general/SystemeAutomatise.jsx
+++ b/src/components/calculateurs/general/SystemeAutomatise.jsx
@@ -3,6 +3,7 @@ import { useCalculateurGeneral } from '../../../context/CalculateurGeneralContex
 import { validateParams, validateEmployeeReplacement } from '../../../utils/validationService';
 import InfoBulle from '../../communs/InfoBulle';
 import { descriptionSystemeAutomatise, descriptionParametresGeneraux } from '../../../utils/parametresDescriptions';
+import FormulasModal from '../../FormulasModal';
 
 /**
  * Composant pour les paramètres du système automatisé
@@ -18,6 +19,9 @@ const SystemeAutomatise = () => {
   
   // État local pour les erreurs de validation
   const [erreurs, setErreurs] = useState({});
+  
+  // État pour le modal de formules
+  const [isFormulasModalOpen, setIsFormulasModalOpen] = useState(false);
   
   // Fonction pour mettre à jour un paramètre spécifique
   const updateParametre = (param, value) => {
@@ -876,17 +880,23 @@ const SystemeAutomatise = () => {
 
       {/* Lien vers la documentation des formules */}
       <div className="mt-6 text-center">
-        <a 
-          href="/docs/formules-calculateur-general.md" 
-          target="_blank"
-          className="text-sm text-blue-600 hover:text-blue-800 hover:underline flex items-center justify-center"
+        <button 
+          onClick={() => setIsFormulasModalOpen(true)}
+          className="text-sm text-blue-600 hover:text-blue-800 hover:underline flex items-center justify-center mx-auto"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           Consulter la documentation détaillée des formules utilisées
-        </a>
+        </button>
       </div>
+
+      {/* Modal des formules */}
+      <FormulasModal 
+        isOpen={isFormulasModalOpen} 
+        onClose={() => setIsFormulasModalOpen(false)} 
+        document="formules-calculateur-general.md"
+      />
 
       {/* Affichage d'erreurs globales si nécessaire */}
       {Object.keys(erreurs).length > 0 && (


### PR DESCRIPTION
## Description
Cette pull request met à jour les boutons de documentation dans les composants du calculateur général pour qu'ils utilisent le modal des formules ajouté dans la PR #60, au lieu de rediriger vers des fichiers Markdown externes.

### Fichiers modifiés
- `src/components/calculateurs/general/SystemeActuel.jsx`
- `src/components/calculateurs/general/SystemeAutomatise.jsx`
- `src/components/calculateurs/general/ResultatsROI.jsx`

### Détails des modifications
1. Remplacement des liens `<a href="...">` par des boutons `<button>` qui déclenchent l'ouverture du modal
2. Ajout d'un état local `isFormulasModalOpen` à chaque composant
3. Intégration du composant `FormulasModal` avec les propriétés appropriées
4. Conservation du style et de la position des boutons pour maintenir la cohérence de l'interface

### Avantages
- Expérience utilisateur améliorée : les utilisateurs restent dans l'application au lieu d'être redirigés vers une autre page
- Cohérence de l'interface : tous les boutons de documentation utilisent désormais le même modal
- Meilleure visibilité du contenu : le modal met en valeur la documentation et facilite sa lecture

### Tests effectués
- Vérification que les boutons ouvrent correctement le modal avec le bon document
- Validation que le modal se ferme correctement lorsque l'utilisateur clique sur le bouton "Fermer"
- Confirmation que le style et le positionnement des boutons respectent l'interface existante