### PR TITLE
Amélioration du calculateur ROI pour l'industrie des pâtes et papiers

### DIFF
--- a/src/components/patesPapiers/components/ParametresOperationnels.jsx
+++ b/src/components/patesPapiers/components/ParametresOperationnels.jsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Composant affichant les paramètres opérationnels clés
+ * Permet une comparaison visuelle entre système actuel et automatisé
+ * @param {Object} props - Les propriétés du composant
+ * @returns {JSX.Element} Composant de paramètres opérationnels
+ */
+const ParametresOperationnels = ({ resultats, parametresGeneraux, parametresSystemeActuel, parametresSystemeAutomatise }) => {
+  const { parametresOperationnels } = resultats;
+  const { 
+    tempsCycleActuel, 
+    tempsCycleAutomatise, 
+    gainProductivite, 
+    heuresOperationAnnuelles,
+    coutParBallotActuel,
+    coutParBallotAutomatise,
+    economieParBallot
+  } = parametresOperationnels;
+
+  // Ballots par jour
+  const ballotsParJourActuel = parametresSystemeActuel.capacite * parametresGeneraux.heuresOperationParJour;
+  const ballotsParJourAutomatise = parametresSystemeAutomatise.capaciteTraitement * parametresGeneraux.heuresOperationParJour;
+  const gainBallotsParJour = ((ballotsParJourAutomatise - ballotsParJourActuel) / ballotsParJourActuel) * 100;
+
+  // Tonnes par jour
+  const tonnesParJourActuel = (ballotsParJourActuel * parametresGeneraux.tonnageAnnuel) / 
+                             (parametresGeneraux.joursOperationParAn * ballotsParJourActuel);
+  const tonnesParJourAutomatise = (ballotsParJourAutomatise * parametresGeneraux.tonnageAnnuel) / 
+                                 (parametresGeneraux.joursOperationParAn * ballotsParJourActuel);
+  const gainTonnesParJour = ((tonnesParJourAutomatise - tonnesParJourActuel) / tonnesParJourActuel) * 100;
+
+  // Consommation énergétique par ballot
+  const energieParBallotActuel = parametresSystemeActuel.energie / 
+                               (parametresSystemeActuel.capacite * heuresOperationAnnuelles);
+  const energieParBallotAutomatise = parametresSystemeAutomatise.coutEnergie / 
+                                  (parametresSystemeAutomatise.capaciteTraitement * heuresOperationAnnuelles);
+  const reductionEnergieParBallot = ((energieParBallotActuel - energieParBallotAutomatise) / energieParBallotActuel) * 100;
+
+  // Productivité par employé
+  const productiviteParEmployeActuel = ballotsParJourActuel / parametresSystemeActuel.nombreEmployes;
+  const productiviteParEmployeAutomatise = ballotsParJourAutomatise / 
+                                        (parametresSystemeActuel.nombreEmployes - parametresSystemeAutomatise.nbEmployesRemplaces);
+  const gainProductiviteParEmploye = ((productiviteParEmployeAutomatise - productiviteParEmployeActuel) / productiviteParEmployeActuel) * 100;
+
+  return (
+    <div className="mt-6 p-4 bg-gray-50 rounded-lg">
+      <h3 className="text-lg font-semibold text-gray-800 mb-3">Paramètres opérationnels clés</h3>
+      
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        {/* Temps de cycle */}
+        <div className="bg-white p-3 rounded shadow-sm">
+          <h4 className="text-sm font-medium text-gray-600">Temps de cycle</h4>
+          <div className="flex justify-between mt-2">
+            <div>
+              <span className="text-xs text-gray-500">Actuel</span>
+              <p className="text-lg font-bold">{tempsCycleActuel.toFixed(1)} s</p>
+            </div>
+            <div>
+              <span className="text-xs text-gray-500">Automatisé</span>
+              <p className="text-lg font-bold text-green-600">{tempsCycleAutomatise.toFixed(1)} s</p>
+            </div>
+          </div>
+          <div className="mt-2 text-xs text-gray-500">
+            <span className="font-medium text-green-600">
+              -{(100 - (tempsCycleAutomatise / tempsCycleActuel * 100)).toFixed(1)}%
+            </span> de temps par ballot
+          </div>
+        </div>
+        
+        {/* Ballots par jour */}
+        <div className="bg-white p-3 rounded shadow-sm">
+          <h4 className="text-sm font-medium text-gray-600">Ballots par jour</h4>
+          <div className="flex justify-between mt-2">
+            <div>
+              <span className="text-xs text-gray-500">Actuel</span>
+              <p className="text-lg font-bold">
+                {ballotsParJourActuel.toFixed(0)}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-gray-500">Automatisé</span>
+              <p className="text-lg font-bold text-green-600">
+                {ballotsParJourAutomatise.toFixed(0)}
+              </p>
+            </div>
+          </div>
+          <div className="mt-2 text-xs text-gray-500">
+            <span className="font-medium text-green-600">
+              +{gainBallotsParJour.toFixed(1)}%
+            </span> de production
+          </div>
+        </div>
+        
+        {/* Coût par ballot */}
+        <div className="bg-white p-3 rounded shadow-sm">
+          <h4 className="text-sm font-medium text-gray-600">Coût par ballot</h4>
+          <div className="flex justify-between mt-2">
+            <div>
+              <span className="text-xs text-gray-500">Actuel</span>
+              <p className="text-lg font-bold">{coutParBallotActuel.toFixed(2)} $</p>
+            </div>
+            <div>
+              <span className="text-xs text-gray-500">Automatisé</span>
+              <p className="text-lg font-bold text-green-600">{coutParBallotAutomatise.toFixed(2)} $</p>
+            </div>
+          </div>
+          <div className="mt-2 text-xs text-gray-500">
+            Économie de <span className="font-medium text-green-600">{economieParBallot.toFixed(2)} $</span> par ballot
+          </div>
+        </div>
+        
+        {/* Tonnes par jour */}
+        <div className="bg-white p-3 rounded shadow-sm">
+          <h4 className="text-sm font-medium text-gray-600">Tonnes par jour</h4>
+          <div className="flex justify-between mt-2">
+            <div>
+              <span className="text-xs text-gray-500">Actuel</span>
+              <p className="text-lg font-bold">{tonnesParJourActuel.toFixed(1)}</p>
+            </div>
+            <div>
+              <span className="text-xs text-gray-500">Automatisé</span>
+              <p className="text-lg font-bold text-green-600">{tonnesParJourAutomatise.toFixed(1)}</p>
+            </div>
+          </div>
+          <div className="mt-2 text-xs text-gray-500">
+            <span className="font-medium text-green-600">
+              +{gainTonnesParJour.toFixed(1)}%
+            </span> de capacité
+          </div>
+        </div>
+        
+        {/* Énergie par ballot */}
+        <div className="bg-white p-3 rounded shadow-sm">
+          <h4 className="text-sm font-medium text-gray-600">Énergie par ballot</h4>
+          <div className="flex justify-between mt-2">
+            <div>
+              <span className="text-xs text-gray-500">Actuel</span>
+              <p className="text-lg font-bold">{energieParBallotActuel.toFixed(3)} $</p>
+            </div>
+            <div>
+              <span className="text-xs text-gray-500">Automatisé</span>
+              <p className="text-lg font-bold text-green-600">{energieParBallotAutomatise.toFixed(3)} $</p>
+            </div>
+          </div>
+          <div className="mt-2 text-xs text-gray-500">
+            <span className="font-medium text-green-600">
+              -{reductionEnergieParBallot.toFixed(1)}%
+            </span> d'énergie
+          </div>
+        </div>
+        
+        {/* Productivité par employé */}
+        <div className="bg-white p-3 rounded shadow-sm">
+          <h4 className="text-sm font-medium text-gray-600">Ballots par employé/jour</h4>
+          <div className="flex justify-between mt-2">
+            <div>
+              <span className="text-xs text-gray-500">Actuel</span>
+              <p className="text-lg font-bold">{productiviteParEmployeActuel.toFixed(0)}</p>
+            </div>
+            <div>
+              <span className="text-xs text-gray-500">Automatisé</span>
+              <p className="text-lg font-bold text-green-600">{productiviteParEmployeAutomatise.toFixed(0)}</p>
+            </div>
+          </div>
+          <div className="mt-2 text-xs text-gray-500">
+            <span className="font-medium text-green-600">
+              +{gainProductiviteParEmploye.toFixed(1)}%
+            </span> de productivité
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ParametresOperationnels.propTypes = {
+  resultats: PropTypes.object.isRequired,
+  parametresGeneraux: PropTypes.object.isRequired,
+  parametresSystemeActuel: PropTypes.object.isRequired,
+  parametresSystemeAutomatise: PropTypes.object.isRequired
+};
+
+export default ParametresOperationnels;

--- a/src/components/patesPapiers/components/ResultatsSommaire.jsx
+++ b/src/components/patesPapiers/components/ResultatsSommaire.jsx
@@ -10,11 +10,18 @@ import React from 'react';
  */
 const ResultatsSommaire = ({ resultats, parametresSystemeActuel, parametresSystemeAutomatise }) => {
   const { 
-    roi, delaiRecuperation, van, tri, economieAnnuelle, economiesSecurite, economiesTempsArret 
+    roi, roiActualise, delaiRecuperation, delaiRecuperationActualise, van, tri, indiceRentabilite,
+    economieAnnuelle, economiesSecurite, economiesTempsArret 
   } = resultats;
   
   const { capacite: capaciteActuelle } = parametresSystemeActuel;
-  const { capaciteTraitement, nbEmployesRemplaces, reductionAccidents } = parametresSystemeAutomatise;
+  const { 
+    capaciteTraitement, 
+    nbEmployesRemplaces, 
+    reductionAccidents, 
+    reductionDechet,
+    reductionEmpreinteCO2
+  } = parametresSystemeAutomatise;
   
   return (
     <div className="bg-white p-4 rounded-lg shadow">
@@ -27,14 +34,28 @@ const ResultatsSommaire = ({ resultats, parametresSystemeActuel, parametresSyste
       
       <div className="grid grid-cols-2 gap-4 mb-6">
         <div className="bg-green-50 p-3 rounded">
-          <h3 className="text-sm font-medium text-gray-700">ROI global</h3>
+          <h3 className="text-sm font-medium text-gray-700">ROI simple</h3>
           <p className="text-2xl font-bold text-green-800">{roi.toFixed(2)}%</p>
+          <p className="text-xs text-gray-500 mt-1">Non actualisé</p>
+        </div>
+        <div className="bg-green-50 p-3 rounded">
+          <h3 className="text-sm font-medium text-gray-700">ROI actualisé</h3>
+          <p className="text-2xl font-bold text-green-700">{roiActualise.toFixed(2)}%</p>
+          <p className="text-xs text-gray-500 mt-1">Tenant compte de la valeur temporelle</p>
         </div>
         <div className="bg-blue-50 p-3 rounded">
           <h3 className="text-sm font-medium text-gray-700">Délai de récupération</h3>
           <p className={`text-2xl font-bold ${delaiRecuperation <= 2 ? 'text-green-600' : 'text-blue-800'}`}>
             {delaiRecuperation.toFixed(2)} ans
           </p>
+          <p className="text-xs text-gray-500 mt-1">Non actualisé</p>
+        </div>
+        <div className="bg-blue-50 p-3 rounded">
+          <h3 className="text-sm font-medium text-gray-700">Délai de récup. actualisé</h3>
+          <p className={`text-2xl font-bold ${delaiRecuperationActualise <= 2.5 ? 'text-green-600' : 'text-blue-700'}`}>
+            {delaiRecuperationActualise.toFixed(2)} ans
+          </p>
+          <p className="text-xs text-gray-500 mt-1">Tenant compte de la valeur temporelle</p>
         </div>
         <div className="bg-purple-50 p-3 rounded">
           <h3 className="text-sm font-medium text-gray-700">VAN</h3>
@@ -44,7 +65,7 @@ const ResultatsSommaire = ({ resultats, parametresSystemeActuel, parametresSyste
         </div>
         <div className="bg-indigo-50 p-3 rounded">
           <h3 className="text-sm font-medium text-gray-700">TRI</h3>
-          <p className="text-2xl font-bold text-indigo-800">{tri.toFixed(2)}%</p>
+          <p className="text-2xl font-bold text-indigo-800">{tri ? tri.toFixed(2) : "N/A"}%</p>
         </div>
       </div>
       
@@ -54,6 +75,13 @@ const ResultatsSommaire = ({ resultats, parametresSystemeActuel, parametresSyste
           <p className="text-2xl font-bold text-yellow-700">
             {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(economieAnnuelle)}
           </p>
+        </div>
+        <div className="flex-1 bg-emerald-50 p-3 rounded">
+          <h3 className="text-sm font-medium text-gray-700">Indice de rentabilité</h3>
+          <p className={`text-2xl font-bold ${indiceRentabilite >= 1.5 ? 'text-emerald-700' : 'text-emerald-600'}`}>
+            {indiceRentabilite.toFixed(2)}
+          </p>
+          <p className="text-xs text-gray-500 mt-1">VAN / Investissement</p>
         </div>
       </div>
       
@@ -77,6 +105,18 @@ const ResultatsSommaire = ({ resultats, parametresSystemeActuel, parametresSyste
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
             </svg>
             <span>Réduction des accidents de <strong>{reductionAccidents}%</strong></span>
+          </div>
+          <div className="flex items-center">
+            <svg className="h-5 w-5 text-green-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+            </svg>
+            <span>Réduction des déchets de <strong>{reductionDechet}%</strong></span>
+          </div>
+          <div className="flex items-center">
+            <svg className="h-5 w-5 text-green-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+            </svg>
+            <span>Réduction de l'empreinte CO₂ de <strong>{reductionEmpreinteCO2}%</strong></span>
           </div>
         </div>
       </div>

--- a/src/components/patesPapiers/components/onglets/DetailsFinanciers.jsx
+++ b/src/components/patesPapiers/components/onglets/DetailsFinanciers.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import FluxTresorerieGraphique from '../graphiques/FluxTresorerieGraphique';
 import useGraphiques from '../../hooks/useGraphiques';
 
@@ -13,6 +13,9 @@ const DetailsFinanciers = ({
   parametresGeneraux,
   resultats
 }) => {
+  // État pour le type de flux à afficher
+  const [typeFlux, setTypeFlux] = useState('cumul'); // 'cumul' ou 'annuel'
+  
   // Utilisation du hook personnalisé pour générer les données des graphiques
   const dataGraphiques = useGraphiques(
     parametresSystemeActuel,
@@ -33,8 +36,20 @@ const DetailsFinanciers = ({
     subventions
   } = parametresSystemeAutomatise;
   
+  // Extraction des paramètres généraux
+  const { tauxActualisation } = parametresGeneraux;
+  
   // Extraction des valeurs de résultats
-  const { roi, delaiRecuperation, van, tri } = resultats;
+  const { 
+    roi, roiActualise, delaiRecuperation, delaiRecuperationActualise, 
+    van, tri, indiceRentabilite, parametresOperationnels 
+  } = resultats;
+  
+  // Extraction des paramètres opérationnels
+  const { tco } = parametresOperationnels;
+  
+  // Investissement initial total
+  const investissementInitial = coutSysteme + coutInstallation + coutIngenierie + coutFormation - subventions;
   
   return (
     <div className="grid grid-cols-1 gap-8">
@@ -80,7 +95,33 @@ const DetailsFinanciers = ({
                   <tr className="border-t border-gray-400">
                     <td className="px-4 py-2 text-left font-bold">Total de l'investissement</td>
                     <td className="px-4 py-2 text-right font-bold">
-                      {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'USD' }).format(coutSysteme + coutInstallation + coutIngenierie + coutFormation - subventions)}
+                      {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'USD' }).format(investissementInitial)}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            
+            <h3 className="font-medium text-gray-700 mb-3 mt-6">Coût total de possession (TCO)</h3>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <tbody>
+                  <tr className="border-t">
+                    <td className="px-4 py-2 text-left">Investissement initial</td>
+                    <td className="px-4 py-2 text-right font-medium">
+                      {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'USD' }).format(investissementInitial)}
+                    </td>
+                  </tr>
+                  <tr className="border-t">
+                    <td className="px-4 py-2 text-left">Coûts opérationnels actualisés ({dureeVie} ans)</td>
+                    <td className="px-4 py-2 text-right font-medium">
+                      {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'USD' }).format(tco - investissementInitial)}
+                    </td>
+                  </tr>
+                  <tr className="border-t border-gray-400">
+                    <td className="px-4 py-2 text-left font-bold">TCO sur {dureeVie} ans</td>
+                    <td className="px-4 py-2 text-right font-bold">
+                      {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'USD' }).format(tco)}
                     </td>
                   </tr>
                 </tbody>
@@ -100,9 +141,21 @@ const DetailsFinanciers = ({
                     </td>
                   </tr>
                   <tr className="border-t">
+                    <td className="px-4 py-2 text-left">ROI actualisé</td>
+                    <td className="px-4 py-2 text-right font-medium">
+                      {roiActualise.toFixed(2)}%
+                    </td>
+                  </tr>
+                  <tr className="border-t">
                     <td className="px-4 py-2 text-left">Délai de récupération</td>
                     <td className="px-4 py-2 text-right font-medium">
                       {delaiRecuperation.toFixed(2)} ans
+                    </td>
+                  </tr>
+                  <tr className="border-t">
+                    <td className="px-4 py-2 text-left">Délai de récupération actualisé</td>
+                    <td className="px-4 py-2 text-right font-medium">
+                      {delaiRecuperationActualise.toFixed(2)} ans
                     </td>
                   </tr>
                   <tr className="border-t">
@@ -114,17 +167,62 @@ const DetailsFinanciers = ({
                   <tr className="border-t">
                     <td className="px-4 py-2 text-left">Taux de Rendement Interne (TRI)</td>
                     <td className="px-4 py-2 text-right font-medium">
-                      {tri.toFixed(2)}%
+                      {tri ? tri.toFixed(2) : "N/A"}%
+                    </td>
+                  </tr>
+                  <tr className="border-t">
+                    <td className="px-4 py-2 text-left">Indice de rentabilité (IR)</td>
+                    <td className="px-4 py-2 text-right font-medium">
+                      {indiceRentabilite.toFixed(2)}
+                    </td>
+                  </tr>
+                  <tr className="border-t">
+                    <td className="px-4 py-2 text-left">Taux d'actualisation</td>
+                    <td className="px-4 py-2 text-right font-medium">
+                      {tauxActualisation}%
                     </td>
                   </tr>
                 </tbody>
               </table>
             </div>
+            
+            <div className="mt-6 p-3 bg-blue-50 rounded-lg">
+              <h3 className="font-medium text-blue-800 mb-2">Comment interpréter ces indicateurs?</h3>
+              <ul className="text-sm space-y-2 text-gray-700">
+                <li><strong>ROI</strong>: Rendement total de l'investissement sur toute la durée de vie.</li>
+                <li><strong>ROI actualisé</strong>: Tient compte de la valeur temporelle de l'argent.</li>
+                <li><strong>Délai de récupération</strong>: Temps nécessaire pour récupérer l'investissement initial.</li>
+                <li><strong>VAN</strong>: Valeur créée par l'investissement en tenant compte du taux d'actualisation.</li>
+                <li><strong>TRI</strong>: Taux de rendement annualisé du projet.</li>
+                <li><strong>IR</strong>: Rapport entre la VAN et l'investissement initial (>1 est favorable).</li>
+              </ul>
+            </div>
           </div>
         </div>
         
-        <div className="mb-8">
-          <FluxTresorerieGraphique data={dataGraphiques.dataCumulatif} />
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="font-medium text-gray-700">Flux de trésorerie</h3>
+            <div className="flex space-x-2">
+              <button 
+                className={`px-3 py-1 text-sm rounded ${typeFlux === 'cumul' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+                onClick={() => setTypeFlux('cumul')}
+              >
+                Cumulatif
+              </button>
+              <button 
+                className={`px-3 py-1 text-sm rounded ${typeFlux === 'annuel' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+                onClick={() => setTypeFlux('annuel')}
+              >
+                Annuel
+              </button>
+            </div>
+          </div>
+          {typeFlux === 'cumul' ? (
+            <FluxTresorerieGraphique data={dataGraphiques.dataCumulatif} />
+          ) : (
+            <FluxTresorerieGraphique data={dataGraphiques.dataAnnuel} />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/patesPapiers/components/onglets/VueGenerale.jsx
+++ b/src/components/patesPapiers/components/onglets/VueGenerale.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ParametresBase from '../ParametresBase';
 import ParametresAvances from '../ParametresAvances';
 import ResultatsSommaire from '../ResultatsSommaire';
+import ParametresOperationnels from '../ParametresOperationnels';
 
 /**
  * Composant pour l'onglet Vue générale
@@ -42,6 +43,14 @@ const VueGenerale = ({
           parametresSystemeAutomatise={parametresSystemeAutomatise}
         />
       </div>
+      
+      {/* Paramètres opérationnels clés (toujours visibles) */}
+      <ParametresOperationnels
+        resultats={resultats}
+        parametresGeneraux={parametresGeneraux}
+        parametresSystemeActuel={parametresSystemeActuel}
+        parametresSystemeAutomatise={parametresSystemeAutomatise}
+      />
       
       {/* Paramètres avancés - affichage conditionnel */}
       {ui.afficherDetails && (


### PR DESCRIPTION
## Améliorations du calculateur ROI pour l'industrie des pâtes et papiers

Cette pull request implémente les recommandations issues de l'audit des calculs financiers et des paramètres.

### Principales améliorations

#### 1. Calculs financiers optimisés
- Ajout du ROI actualisé tenant compte de la valeur temporelle de l'argent
- Amélioration du calcul du TRI avec la méthode de Newton-Raphson pour une meilleure précision
- Ajout du délai de récupération actualisé
- Calcul de l'indice de rentabilité (VAN / Investissement initial)
- Calcul du coût total de possession (TCO) sur la durée de vie

#### 2. Paramètres opérationnels clés
- Nouveau composant affichant les métriques opérationnelles clés :
  - Temps de cycle comparatif (actuel vs automatisé)
  - Ballots traités par jour
  - Tonnes traitées par jour
  - Coût par ballot
  - Consommation énergétique
  - Productivité par employé

#### 3. Interface utilisateur améliorée
- Restructuration des résultats financiers pour comparer métriques simples et actualisées
- Ajout d'options pour visualiser les flux de trésorerie annuels ou cumulatifs
- Amélioration des graphiques avec des données plus pertinentes
- Ajout d'explications sur l'interprétation des indicateurs financiers

### Tests effectués
- Vérification des calculs financiers avec des données de test
- Validation de l'affichage pour différentes configurations

Ces améliorations permettront aux utilisateurs de mieux comprendre les bénéfices financiers et opérationnels d'un système automatisé dans l'industrie des pâtes et papiers, conformément aux recommandations de l'audit.